### PR TITLE
Formatting and syntax corrected

### DIFF
--- a/docs/creating-manifest/actions.md
+++ b/docs/creating-manifest/actions.md
@@ -1477,7 +1477,7 @@ assert:
 Failed comparing value will be marked in red colored text:
 ![assert-failed](/img/assert-failed.jpg)
 
-Also, there is an ability to set custom messages in cousole log instead default text *ASSERT*:
+Also, there is an ability to set custom messages in console log instead default text *ASSERT*:
 @@@
 ```yaml
 type: update

--- a/docs/creating-manifest/basic-configs.md
+++ b/docs/creating-manifest/basic-configs.md
@@ -129,8 +129,8 @@ The list of available parameters are:
 
 - `nodeType` *[required]* - the defined node type. The list of available stacks are <a href="/creating-manifest/selecting-containers/#supported-stacks" target="_blank">here</a>. 
 - `cloudlets` *[optional]* - a number of dynamic cloudlets. The default value is 0. `flexible` is an alias. 
-- `fixedCloudlets` *[optional]* - a mount of fixed cloudlets. The default value is 1.
-- `count` *[optional]* - a mount of nodes in one group. The default value is 1.
+- `fixedCloudlets` *[optional]* - amount of fixed cloudlets. The default value is 1.
+- `count` *[optional]* - amount of nodes in one group. The default value is 1.
 - `nodeGroup` *[optional]* - the defined node layer. A docker-based containers can be predefined in any custom node group.
 - `displayName` *[optional]* - node's display name (i.e. <a href="https://docs.jelastic.com/environment-aliases" target="_blank">alias</a>)                                         
 - `extip` *[optional]* - attaching public IP address to a container. The default value is *'false'*.

--- a/docs/creating-manifest/basic-configs.md
+++ b/docs/creating-manifest/basic-configs.md
@@ -195,36 +195,32 @@ If multiple regions are available, the environment will be created at one that i
 -   stating a specific region name in the **region** parameter within JPS manifest
 -   specifying filter conditions (described below) in the **targetRegions** parameter within JPS manifest
 
-
-**Note**: in case both options (*targetRegions* and *region*) are added to the manifest, the *region* option will be ignored.
-
-
+!!! note
+    In case both options (*targetRegions* and *region*) are added to the manifest, the *region* option will be ignored.
 
 The *targetRegions* option has multiple additional parameters for filtering the regions:
 
-
--   `name` *[optional]{string}* - text or JavaScript RegExp argument to filter regions by name that can be found in JCA -> Hardware Nodes -> Name column:   
+-   `name` *[optional]{string}* - text or JavaScript RegExp argument to filter regions by name that can be found in JCA -> Hardware Nodes -> Name column :   
 *“targetRegions”: { “name”: “hn01.azure-cus” }*  
--   `uniqueName` *[optional]{string}* - name alias :
+-   `uniqueName` *[optional]{string}* - name alias :   
 *“targetRegions”: { “uniqueName”: “hn01.azure-cus” }*
--   `displayName` *[optional]{string}* - text or JavaScript RegExp argument to filter regions by name that is displayed at the dashboard:
+-   `displayName` *[optional]{string}* - text or JavaScript RegExp argument to filter regions by name that is displayed at the dashboard:   
 *“targetRegions”: { “displayName”: “Azure CUS” }*
--   `isActive` *[optional]{boolean}* - filters regions by logical values true or false, according to its status in JCA->Regions->Status column.
+-   `isActive` *[optional]{boolean}* - filters regions by logical values true or false, according to its status in JCA->Regions->Status column :   
 *“targetRegions”: { “isActive”: “false” }*
--   `isRegionMigrationAllowed` *[optional]{boolean}* - filters regions by logical values true or false, according to the possibility to enable live migration   
+-   `isRegionMigrationAllowed` *[optional]{boolean}* - filters regions by logical values true or false, according to the possibility to enable live migration:   
 *“targetRegions”: { “isRegionMigrationAllowed”: “true” }*
--   `region` *[optional]{number}* - filters by region’s id:
+-   `region` *[optional]{number}* - filters by region’s id:   
 *“targetRegions”: { “region”: “1” }*
--   `vzTypes` *[optional]{string array}* - text or JavaScript RegExp argument to filter region’s by virtualization type: “pvc”, “vz6”, “pcs-storage”, “vz7”, where “pvc” for Parallels Virtuozzo Containers, “vz6” for Virtuozzo 6, “pcs-storage” for Parallels Cloud Storage, “vz7” for Virtuozzo 7
+-   `vzTypes` *[optional]{string array}* - text or JavaScript RegExp argument to filter region’s by virtualization type: “pvc”, “vz6”, “pcs-storage”, “vz7”, where “pvc” for Parallels Virtuozzo Containers, “vz6” for Virtuozzo 6, “pcs-storage” for Parallels Cloud Storage, “vz7” for Virtuozzo 7:   
 *“targetRegions”: { “vzTypes”: “pvc” }*
--   `type` *[optional]{string array}* - vzTypes alias
-*"targetRegions": { “type”: “pvc” }*
-   
->
+-   `type` *[optional]{string array}* - vzTypes alias:   
+*“targetRegions”: { “type”: “pvc” }*
+
 !!! note
-    > All fields in filter could be passed as an Array of Strings or String. Each string could be a valid JavaScript RegExp argument. Even boolean values can be as RegExp argument. Examples:
-*“targetRegions”: {“isActive”: “f.*” }*   
-*“targetRegions”: { “displayName”: [".\*O.\*", “.\*A.\*”, “.\*P.\*”] }* 
+    All fields in filter could be passed as an Array of Strings or String. Each string could be a valid JavaScript RegExp argument. Even boolean values can be as RegExp argument. Examples:   
+    *“targetRegions”: {“isActive”: “f.\*” }*   
+    *“targetRegions”: { “displayName”: [".\*O.\*", “.\*A.\*”, “.\*P.\*”] }* 
 <!-- RegionFiltering section -->
 
 <!--##Docker Actions-->

--- a/docs/creating-manifest/visual-settings.md
+++ b/docs/creating-manifest/visual-settings.md
@@ -77,7 +77,7 @@ where:
 - `prepopulate` *[optional]* - link to a script, that will fetch default field values
 - `fields` - array of fields that will be displayed in a custom form
     - `showIf` - shows/hides field by condition (applicable only to *radio-fieldset* field)
-    - `type` *[optional]* - input field type. Default value is *'string'*. Possible values:
+    - `type` *[optional]* - input field type. The default value is *'string'*. Possible values:
         * `string` - [basic](#string) text field
         * `text`  - [multiline](#text) text field
         * `list` - drop-down menu with [textboxes](#list)
@@ -100,18 +100,18 @@ where:
         * `hostpicker` - drop-down menu with [environment hosts](#hostpicker)
         * `host-picker` - alias to `hostpicker`
         * `toggle` - [switcher](#toggle) between two values
-    - `inputType` *[optional]* - type attribute of the input field (e.g. *radio*, *text*, *password*, *file*, etc.). Default value is *'text'*. See more info on <a href="https://www.w3.org/wiki/HTML/Elements/input#Point" target="_blank">type attribute</a>.
+    - `inputType` *[optional]* - type attribute of the input field (e.g. *radio*, *text*, *password*, *file*, etc.). The default value is *'text'*. See more info on <a href="https://www.w3.org/wiki/HTML/Elements/input#Point" target="_blank">type attribute</a>.
     - `name` - input field name, that can be used to get a parameter value through the `${settings.your_input_name}` placeholder within scripts or manifests
     - `default` *[optional]* - default value for the input field
     - `caption` *[optional]* - field label
     - `placeholder` *[optional]* - used <a href="/reference/placeholders/" target="blank">placeholders</a>
     - `required` *[optional]* - possible values are *'true'* & *'false'*. If left empty, default value is *'true'*.
-    - `regex` *[optional]* - constructor for testing JavaScript RegExp object that refers to the field value, during validation. If test fails, the field will be marked as invalid using *regexText*. Default value is *'null'*.
-    - `regexText` *[optional]* - displays error message in case of *regex* test failure during validation. Default value is *' '* (blank space).
+    - `regex` *[optional]* - constructor for testing JavaScript RegExp object that refers to the field value, during validation. If test fails, the field will be marked as invalid using *regexText*. The default value is *'null'*.
+    - `regexText` *[optional]* - displays error message in case of *regex* test failure during validation. The default value is *' '* (blank space).
     - `vtype` *[optional]* - validation type name. Possible values:
-        - `alpha` - keystroke filter mask applied to alpha input. Default value is *'/[a-z_]/i'*.
-        - `alphanum` - keystroke filter mask applied to alphanumeric input. Default value is *'/[a-z0-9_]/i'*.
-        - `email` - keystroke filter mask applied to email input. Default value is *'/[a-z0-9_.-+\'@]/i'*. See <a href="http://docs.sencha.com/extjs/3.4.0/#!/api/Ext.form.VTypes-method-email" target="_blank">appropriate method</a> for more information about complex email validation.
+        - `alpha` - keystroke filter mask applied to alpha input. The default value is *'/[a-z_]/i'*.
+        - `alphanum` - keystroke filter mask applied to alphanumeric input. The default value is *'/[a-z0-9_]/i'*.
+        - `email` - keystroke filter mask applied to email input. The default value is *'/[a-z0-9_.-+\'@]/i'*. See <a href="http://docs.sencha.com/extjs/3.4.0/#!/api/Ext.form.VTypes-method-email" target="_blank">appropriate method</a> for more information about complex email validation.
         - `URL` - keystroke filter mask applied to URL input
     - `vtypeText` *[optional]* - custom error message to be displayed instead of the default one, provided by *vtype* for this field. The default value is *' '* (blank space).
 
@@ -147,7 +147,7 @@ fields:
 where:
 
 - `caption` *[optional]* - field label
-- `hideLabel` *[optional] [boolean]* - shows/hides field label. Default value is *'false'*.
+- `hideLabel` *[optional] [boolean]* - shows/hides field label. The default value is *'false'*.
 
 ### text
 Multiline text field.
@@ -176,7 +176,7 @@ fields:
 where:
 
 - `caption` *[optional]* - field label
-- `hideLabel`*[optional] [boolean]* - hides field label. Default value is *'false'*.
+- `hideLabel`*[optional] [boolean]* - hides field label. The default value is *'false'*.
 
 ### list
 Drop-down list and a single-line textbox.
@@ -215,8 +215,8 @@ where:
 
 - `caption` *[optional]* - field label
 - `values` - objects values (*"key"*:*"value"*)
-- `hideLabel` *[optional] [boolean]* - shows/hides field label. Default value is *'false'*.
-- `editable` [optional][boolean] - allows to input custom values. Default value is *'false'*.
+- `hideLabel` *[optional] [boolean]* - shows/hides field label. The default value is *'false'*.
+- `editable` [optional][boolean] - allows to input custom values. The default value is *'false'*.
 
 ### checkbox
 Single checkbox field.
@@ -248,7 +248,7 @@ where:
 
 - `caption` *[optional]* - field label
 - `value` - enables or disables checkbox
-- `hideLabel` *[optional][boolean]* - shows/hides field label. Default value is *'false'*.
+- `hideLabel` *[optional][boolean]* - shows/hides field label. The default value is *'false'*.
 
 ### checkboxlist
 Checkbox grouping.
@@ -285,7 +285,7 @@ where:
 
 - `caption` *[optional]* - field label
 - `values` - checkboxes (*"key"*:*"value"*)
-- `hideLabel` *[optional] [boolean]* - shows/hides field label. Default value is *'false'*.
+- `hideLabel` *[optional] [boolean]* - shows/hides field label. The default value is *'false'*.
 
 ### radiolist
 Radio elements grouping.
@@ -322,7 +322,7 @@ where:
 
 - `caption` *[optional]* - field label
 - `values` - checkboxes (*"key"*:*"value"*)
-- `hideLabel` *[optional][boolean]* - shows/hides field label. Default value is *'false'*.
+- `hideLabel` *[optional][boolean]* - shows/hides field label. The default value is *'false'*.
 
 ### radio-fieldset
 Grouping of the radio elements with <b>*showIf*</b> function.
@@ -393,7 +393,7 @@ where:
 - `default` *[optional]* - field selected upon opening the form
 - `values` - checkboxes (*"key"*:*"value"*)
 - `showIf` - conditional object that shows predefined elements by clicking on the *radio-fieldset* elements. Predefined elements can vary.
-- `hideLabel` *[optional] [boolean]* - shows/hides field label. Default value is *'false'*.
+- `hideLabel` *[optional] [boolean]* - shows/hides field label. The default value is *'false'*.
 - `caption` *[optional]* - field label
 
 Also there is an ability to set an `values` order. It needs to be defined like an array of objects.
@@ -557,10 +557,10 @@ fields:
 
 where:
 
-- `pack` *[optional]* - manages the way items are packed together. Default value is *'start'*. Possible values: *'start'*, *'center'* and *'end'*.
-- `align` *[optional]* - manages the way items are aligned. Default value is *'top'*. Possible values: *'top'*, *'middle'*, *'stretch'*, *'stretchmax'*.
-- `defaultMargins` *[optional]* - default margins for items. Default value is *'0'*.
-- `defaultPadding` *[optional]* - default paddings for items. Default value is *'0'*.
+- `pack` *[optional]* - manages the way items are packed together. The default value is *'start'*. Possible values: *'start'*, *'center'* and *'end'*.
+- `align` *[optional]* - manages the way items are aligned. The default value is *'top'*. Possible values: *'top'*, *'middle'*, *'stretch'*, *'stretchmax'*.
+- `defaultMargins` *[optional]* - default margins for items. The default value is *'0'*.
+- `defaultPadding` *[optional]* - default paddings for items. The default value is *'0'*.
 - `defaultFlex` *[optional]* - horizontal flex for items
 - `items` - elements
 
@@ -600,7 +600,7 @@ where:
 
 - `min` - minimum slider value
 - `max` - maximum slider value
-- `useTips` - displaying tips for the value. Default value is *'true'*.
+- `useTips` - displaying tips for the value. The default value is *'true'*.
 - `caption` *[optional]* - field label
 - `name` *[optional]* - name of the field
 
@@ -635,8 +635,8 @@ where:
 
 - `caption` *[optional]* - field label
 - `name` - name of the field
-- `editable` *[optional][boolean]* - enables/disables the *envlist* field editing. Default value is *'false'*.
-- `valueField` *[optional][string]* - value from environment information, which will be sent to a server. Default value is *'domain'*. Available values are:
+- `editable` *[optional][boolean]* - enables/disables the *envlist* field editing. The default value is *'false'*.
+- `valueField` *[optional][string]* - value from environment information, which will be sent to a server. The default value is *'domain'*. Available values are:
     - *iconCls* - CSS class
     - *isRunning* - checking whether environment status is *running*
     - *shortdomain* - short environment domain name (without platform URL)
@@ -866,7 +866,7 @@ where:
 
 - `caption` *[optional]* - field label
 - `name` *[optional]* - name of the field
-- `markup` - value to initialize the field's display. Default value is *'undefined'*.
+- `markup` - value to initialize the field's display. The default value is *'undefined'*.
 
 ### spinner
 Enhanced input field for entering numeric values, with up/down buttons and arrow keys handling.
@@ -947,7 +947,7 @@ where:
 - `caption` *[optional]* - field label
 - `min` - minimum spinner value
 - `max` - maximum spinner value
-- `editable` *[optional] [boolean]* - enables/disables editing the *numberpicker* field. Default value is *'false'*.
+- `editable` *[optional] [boolean]* - enables/disables editing the *numberpicker* field. The default value is *'false'*.
 
 ### hostpicker
 (*host-picker* is an alias)
@@ -983,8 +983,8 @@ where:
 
 - `name` *[optional]* - name of the field
 - `caption` *[optional]* - field label
-- `editable` *[optional] [boolean]* - enables/disables editing the *envlist* field. Default value is *'false'*.
-- `valueField` *[optional][string]* - value from environment information, which will be sent to a server. Default value is *'domain'*. Available values are:
+- `editable` *[optional] [boolean]* - enables/disables editing the *envlist* field. The default value is *'false'*.
+- `valueField` *[optional][string]* - value from environment information, which will be sent to a server. The default value is *'domain'*. Available values are:
     - *iconCls* - CSS class
     - *isRunning* - checking whether environment status is *running*
     - *shortdomain* - short environment domain name (without platform URL)
@@ -1020,11 +1020,13 @@ where:
 
 - `name` *[optional]* - name of the field
 - `caption` *[optional]* - field label
-- `value` *[boolean]* - enables/disables toggle value. Default value is *'false'*.
+- `value` *[boolean]* - enables/disables toggle value. The default value is *'false'*.
 
-##Target Nodes
+## Dynamic filling of the manifest fields
+Ability to dynamically determine UI in JPS manifest is accessible via [*onBeforeInit*  *onBeforeInstall*](/creating-manifest/events/#onbeforeinit-onbeforeinstall) events.
+
+## Target Nodes
 Target Nodes is an optional method that allows to define environments suitable for JPS installation. This method is available only for the *update* installation type.                                
-
 Filtering for *targetNodes* can be performed by *nodeType*, *nodeGroup*, *dockerOs*, *dockerName* or *dockerTag*.
 @@@
 ```yaml
@@ -1245,13 +1247,13 @@ buttons:
 where:
 
 - `buttons` - button parameters array
-- `confirmText` *[optional]* - custom confirmation text for users. Default value is *'Are you sure?'*.
+- `confirmText` *[optional]* - custom confirmation text for users. The default value is *'Are you sure?'*.
 
 It will be displayed after clicking the appropriate button for an add-on. According to the code above, the text will be the following.
 
 ![Confirm](/img/Confirm.jpg)
 
-- `loadingText` *[optional]* - UI text to be displayed during loading and applying changes. Default value is *'Applying...'*.
+- `loadingText` *[optional]* - UI text to be displayed during loading and applying changes. The default value is *'Applying...'*.
 
 ![LoadingText](/img/LoadingText.jpg)
 
@@ -1321,7 +1323,7 @@ where:
 
 - `settings` - custom form ID. Default is *'main'*.
 - `title` - custom dialog title. If absent, *caption* will be applied.
-- `submitButtonText` - text for submission button in the opened dialog. Default value is *'Apply'*.
+- `submitButtonText` - text for submission button in the opened dialog. The default value is *'Apply'*.
 
 ![SubmitButtonText](/img/SubmitButtonText.jpg)
 


### PR DESCRIPTION
Added link in visual-settings to onBeforeInit onBeforeInstall events.
Some markdown syntax was corrected.
Added article "The" to the sentences like "Default value is..." in purposes to make sentences as they're at web-site now "The default value is..." . I have no idea why the article "The" mostly is absent in the repo now in the basic-configs.md file. 