### PR TITLE
Search Fixed 1.5.2

### DIFF
--- a/3rdparty/mkdocs/mkdocs/themes/mkdocs/mkdocs_theme.yml
+++ b/3rdparty/mkdocs/mkdocs/themes/mkdocs/mkdocs_theme.yml
@@ -3,5 +3,5 @@
 static_templates:
     - 404.html
 
-include_search_page: false
+include_search_page: true
 search_index_only: false

--- a/theme/readthedocs/search.html
+++ b/theme/readthedocs/search.html
@@ -2,7 +2,7 @@
 
 {% block extrahead %}
   <script>var base_url = '{{ base_url }}';</script>
-  <script data-main="{{ base_url }}/mkdocs/js/search.js" src="{{ base_url }}/mkdocs/js/require.js"></script>
+  <script data-main="{{ base_url }}/search/search.js" src="{{ base_url }}/search/require.js"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Enabling "include_search_page: **false**" to "**true**" in file _mkdocs_theme.yml_ - creates directory **search** with all necessary ***.js** files
To find these ***.js** files it's mandatory to change the paths in the _search.html_ files.