### PR TITLE
Spelling errors and VPS to VDS 1.4

### DIFF
--- a/docs/creating-manifest/actions.md
+++ b/docs/creating-manifest/actions.md
@@ -93,7 +93,7 @@ cmd [tomcat6]: curl -fsSL http://example.com/script.sh | /bin/bash -s arg1 arg2
 ```
 @@!
 
-The default `cmd` parameter is **commands**. It can be usefull to set a several commands in the same `cmd` action. For example:
+The default `cmd` parameter is **commands**. It can be useful to set a several commands in the same `cmd` action. For example:
 
 @@@
 ```yaml
@@ -277,7 +277,7 @@ nodeGroup: cp
 ```
 @@!
 
-There is an default parameter `method` for `api` action. This parameter is usefull while setting few api method in one `api` action. For example:
+There is an default parameter `method` for `api` action. This parameter is useful while setting few api method in one `api` action. For example:
 @@@
 ```yaml
 type: update
@@ -792,7 +792,7 @@ where:
 - `nodeId`, `nodeGroup`, `nodeType` - parameters that determine target containers for the action execution (at least one of these parameters is required)                   
 - `string` - node’s display name (i.e. <a href="https://docs.jelastic.com/environment-aliases" target="_blank">alias</a>)                                                                        
 
-The action `setNodeDisplayName` has the default parameter called **displayName**. It is usefull to set display name for few node layers in the same `action`. For example:
+The action `setNodeDisplayName` has the default parameter called **displayName**. It is useful to set display name for few node layers in the same `action`. For example:
 @@@
 ```yaml
 type: update
@@ -846,7 +846,7 @@ where:
 - `nodeId`, `nodeGroup`, `nodeType` - parameters that determine target containers for the action execution (at least one of these parameters is required)                                                       
 - `number` - total number of nodes after the action is finished                                          
 
-The action `setNodeCount` has it own default parameter - **count**. It is usefull to set node count for few node layers in one action. For example:
+The action `setNodeCount` has it own default parameter - **count**. It is useful to set node count for few node layers in one action. For example:
 @@@
 ```yaml
 type: update
@@ -900,7 +900,7 @@ where:
 - `nodeId`, `nodeGroup`, `nodeType` - parameters that determine target containers for the action execution (at least one of these parameters is required)                                                                    
 - `true` or `false` - parameter that allows to attach or detach the external IP address                              
 
-The action `setExtIpEnabled` has  own default parameter *enabled*. It is usefull in case to set external IP address status for few nodes in the same `action`. For example:
+The action `setExtIpEnabled` has  own default parameter *enabled*. It is useful in case to set external IP address status for few nodes in the same `action`. For example:
 @@@
 ```yaml
 type: update
@@ -967,7 +967,7 @@ Available for all nodes
 @@@
 ```yaml
 restartContainers:
-  - nodeId: number or stirng
+  - nodeId: number or string
     nodeGroup: string
     nodeType: string
 ```
@@ -1593,7 +1593,7 @@ name: Return Action
 onInstall:
   return:
     type: success
-    message: Compute node unique identifer - ${nodes.cp.id}
+    message: Compute node unique identifier - ${nodes.cp.id}
 ```
 ```json
 {
@@ -1602,7 +1602,7 @@ onInstall:
   "onInstall": {
     "return": {
       "type": "success",
-      "message": "Compute node unique identifer - ${nodes.cp.id}"
+      "message": "Compute node unique identifier - ${nodes.cp.id}"
     }
   }
 }
@@ -1620,7 +1620,7 @@ name: Return Action
 onInstall:
   - return:
       type: success
-      message: Compute node unique identifer - ${nodes.cp.id}
+      message: Compute node unique identifier - ${nodes.cp.id}
   - restartNodes [cp]
 ```
 ```json
@@ -1630,7 +1630,7 @@ onInstall:
     "onInstall": [{
             "return": {
                 "type": "success",
-                "message": "Compute node unique identifer - ${nodes.cp.id}"
+                "message": "Compute node unique identifier - ${nodes.cp.id}"
             }
         },
         "restartNodes [cp]"

--- a/docs/creating-manifest/basic-configs.md
+++ b/docs/creating-manifest/basic-configs.md
@@ -91,7 +91,7 @@ success: object/string
 - `name` *[required]* - JPS custom name
 - `logo` *[optional]* - JPS image that will be displayed within custom add-ons
 - `description` - text string that describes a template. This section should always follow the template format version section.
-- `homepage` *[optional]* - link to any external aplication source
+- `homepage` *[optional]* - link to any external application source
 - `categories` - categories available for manifests filtering                                                                        
 - `baseUrl` *[optional]* - custom <a href="#relative-links" target="_blank">relative links</a>                                       
 - `settings` *[optional]* - custom form with <a href="/creating-manifest/visual-settings/" target="_blank">predefined user input elements</a>
@@ -99,7 +99,7 @@ success: object/string
     - `type` *[optional]* [array] - region's virtualization types
     - `name` *[optional]* [string] - text or JavaScript RegExp argument to filtering region's by name
 - `region` *[optional]* - region, where an environment will be installed. Option will be used only with **type** `install`.
-`targetRegions` has has a higher priority than `region`. So in case when both of options have been set regions will be filtered according to the `targetRegions` rules.
+`targetRegions` has a higher priority than `region`. So in case when both of options have been set regions will be filtered according to the `targetRegions` rules.
 - `nodes` - an array to describe information about nodes for an installation. Option will be used only with **type** `install`.
 - `engine` *[optional]* - engine <a href="/creating-manifest/selecting-containers/#engine-versions" target="_blank">version</a>, by **default** `java6`
 - `region` *[optional]* - region, where an environment will be installed. Required option for **type** `install`.

--- a/docs/creating-manifest/events.md
+++ b/docs/creating-manifest/events.md
@@ -19,7 +19,7 @@ Each event triggers a particular action on the required application's lifecycle 
 
 Events can be filtered by <a href="/creating-manifest/selecting-containers/#all-containers-by-group" target="_blabk">*nodeGroup*</a>, <a href="/creating-manifest/selecting-containers/#all-containers-by-type" target="_blank">*nodeType*</a>, and <a href="/creating-manifest/selecting-containers/#particular-container" target="_blank">*nodeId*</a> parameters. As a result, the action is executed only when the called event matches specified filtering rules. Otherwise, if no filtering rules are specified, every event is listened by all environment entities.         
 
-The following example describes the events filtering by *nodeGroup* (for the <b>*onAfterScaleOut*</b> event), *nodeType* (for the <b>*onAfterRestartNode*</b> event), and *nodeId* (for the <b>*onAfterResetNodePassword*</b> event). Here, filtering by the compute node group (*[cp]*) is set so that the action is executed after compute nodes are scaled out. The *nodeType* filtering is set so that the action is executed after **Apache 2** nodes are restarted. The *nodeID* filtering is set so that the action is executed after a password from the first compute node in the layer is reseted.
+The following example describes the events filtering by *nodeGroup* (for the <b>*onAfterScaleOut*</b> event), *nodeType* (for the <b>*onAfterRestartNode*</b> event), and *nodeId* (for the <b>*onAfterResetNodePassword*</b> event). Here, filtering by the compute node group (*[cp]*) is set so that the action is executed after compute nodes are scaled out. The *nodeType* filtering is set so that the action is executed after **Apache 2** nodes are restarted. The *nodeID* filtering is set so that the action is executed after a password from the first compute node in the layer is reset.
 @@@
 ```yaml
 type: update
@@ -223,7 +223,7 @@ These monitoring triggers are based on the usage of the following resource types
 
 - **Disk IOPS** - disk input/output rate (in operations per second)                                                            
 
-The units of measurement are *PERCENTAGE* and *SPECIFIC*. The second value is availabe only for **NET_EXT** and **NET_EXT_OUT** resource types.
+The units of measurement are *PERCENTAGE* and *SPECIFIC*. The second value is available only for **NET_EXT** and **NET_EXT_OUT** resource types.
 
 The following example illustrates the subscription to the *onAlert* event. Here, the *log* action is executed if one of the triggers within the compute (*[cp]*) layer is invoked.
 @@@

--- a/docs/creating-manifest/placeholders.md
+++ b/docs/creating-manifest/placeholders.md
@@ -39,7 +39,7 @@ This is the list of placeholders that you can use within the environment section
     - `domain` *[string]* - application domain
     - `protocol` *[string]* - protocol
     - `url` *[string]* - link to application (environment)
-    - `region` *[string]* - a region name where environemnt has been installed
+    - `region` *[string]* - a region name where environment has been installed
     - `displayName` *[string]* - application display name
     - `envName` *[string]* - short domain name (without hosting provider URL)
     - `shortdomain` *[string]* - short domain name (alias to `envName`)
@@ -447,7 +447,7 @@ where:
 
 **The First and the Last Array Elements** 
 
-- `{nodes.cp.first.(key)}` - array element with the the *'0'* index              
+- `{nodes.cp.first.(key)}` - array element with the *'0'* index              
 - `{nodes.sqldb.last.(key)}` - array element with the last ID in the array                      
 
 Here, <b>*key*</b> is the node parameter.                         

--- a/docs/creating-manifest/selecting-containers.md
+++ b/docs/creating-manifest/selecting-containers.md
@@ -66,7 +66,7 @@ The Jelastic Platform supports the following predefined *nodeGroup* values:
 
 - *storage*                   
 
-- *vps*                 
+- *vds* (for VPS)                 
 
 - *build*                           
 
@@ -213,7 +213,7 @@ The Jelastic Platform supports the following predefined *nodeGroup* values:
 
 - **nosqldb** (for NoSQL databases) - *mongodb, mongodb2, couchdb, redis, redis3, cassandra, cassandra2, cassandra3, neo4j, neo4j2-1, neo4j3, orientDB, orientDB2, Percona*                   
 
-- **vps** (for virtual private servers) - *centos6, centos7, ubuntu16-04, windows2008, windows2012*                          
+- **vds** (for virtual private servers, VPS) - *centos6, centos7, ubuntu16-04, windows2008, windows2012*                          
 
 - **cache** (for a cache server) - *memcached*                         
 

--- a/docs/creating-manifest/visual-settings.md
+++ b/docs/creating-manifest/visual-settings.md
@@ -89,7 +89,7 @@ where:
         * `slider` - [slider element](#slider) as a form field
         * `envlist` - [list of environments](#envlist) available for a corresponding account
         * `regionlist` - drop-down menu with a [regions](#regionlist) list
-        * `popupselector` - new [pop-up window](#popupselector) via POST request with posibility to pass additional parameters
+        * `popupselector` - new [pop-up window](#popupselector) via POST request with possibility to pass additional parameters
         * `popup-selector` - alias to `popupselector`
         * `displayfield` - [text field](#displayfield) intended for displaying text
         * `spacer` - alias to `displayfield`

--- a/docs/examples/addon-inside-manifest.md
+++ b/docs/examples/addon-inside-manifest.md
@@ -1,6 +1,6 @@
 #Install Add-on inside Manifest
 
-This manifest provides an environment, that is handled with the help of **Apache PHP** aplication server, is powered by **PHP 7** engine version and has external IP address attached. Subsequently, Public IP address can be detached with the help of the **Add-on** button.
+This manifest provides an environment, that is handled with the help of **Apache PHP** application server, is powered by **PHP 7** engine version and has external IP address attached. Subsequently, Public IP address can be detached with the help of the **Add-on** button.
 ``` json
 {
   "type": "install",

--- a/docs/examples/operation-examples.md
+++ b/docs/examples/operation-examples.md
@@ -1068,7 +1068,7 @@ return jelastic.env.control.CreateEnvironment(sAppid, sSession, sActionkey, oEnv
 
 ##Install Add-on inside Manifest
 
-This manifest provides an environment, that is handled with the help of **Apache PHP** aplication server, is powered by **PHP 7** engine version and has external IP address attached. Subsequently, Public IP address can be detached with the help of the **Add-on** button.
+This manifest provides an environment, that is handled with the help of **Apache PHP** application server, is powered by **PHP 7** engine version and has external IP address attached. Subsequently, Public IP address can be detached with the help of the **Add-on** button.
 ``` json
 {
   "type": "install",


### PR DESCRIPTION
Spelling errors fixed. VPS changed to VDS to get rid of error while executing cmd ob layer: **cmd**[vds]