### PR TITLE
Manifests can be YAML or JSON with .jps extension

### DIFF
--- a/docs/creating-manifest/basic-configs.md
+++ b/docs/creating-manifest/basic-configs.md
@@ -1,6 +1,6 @@
 # Basic Configs
 
-The JPS manifest is a file with <b>*.json*</b> extension, which contains an appropriate code written in JSON format. This manifest file includes the links to the web only dependencies. This file can be named as you require. 
+The JPS manifest is a file with <b>*.jps*</b> extension, with code written in JSON or YAML format. This manifest file includes the links to the web only dependencies. This file can be named as you require. 
 
 The code should contain a set of strings needed for a successful installation of an application. The basis of the code is represented by the following string:
 @@@


### PR DESCRIPTION
This page incorrectly claimed that manifests have .json extension but all cases I've seen use .jps. It also gives examples in YAML / JSON but indicated that manifests are only written in JSON.